### PR TITLE
[DON'T MERGE] Sync fixes

### DIFF
--- a/src/main/java/org/bitcoinj/core/AltcoinBlock.java
+++ b/src/main/java/org/bitcoinj/core/AltcoinBlock.java
@@ -204,7 +204,6 @@ public class AltcoinBlock extends org.bitcoinj.core.Block {
             if (auxpowParams.isAuxPoWBlockVersion(this.getRawVersion())
                 && payload.length >= 160) { // We have at least 2 headers in an Aux block. Workaround for StoredBlocks
                 this.auxpow = new AuxPoW(params, payload, cursor, this, serializer);
-                optimalEncodingMessageSize += auxpow.getOptimalEncodingMessageSize();
             }
         }
 
@@ -218,6 +217,7 @@ public class AltcoinBlock extends org.bitcoinj.core.Block {
         parseAuxPoW();
         if (null != this.auxpow) {
             super.parseTransactions(offset + auxpow.getMessageSize());
+            optimalEncodingMessageSize += auxpow.getMessageSize();
         } else {
             super.parseTransactions(offset);
         }

--- a/src/main/java/org/bitcoinj/core/AuxPoW.java
+++ b/src/main/java/org/bitcoinj/core/AuxPoW.java
@@ -143,8 +143,6 @@ public class AuxPoW extends ChildMessage {
     public int getOptimalEncodingMessageSize() {
         if (optimalEncodingMessageSize != 0)
             return optimalEncodingMessageSize;
-        if (optimalEncodingMessageSize != 0)
-            return optimalEncodingMessageSize;
         optimalEncodingMessageSize = getMessageSize();
         return optimalEncodingMessageSize;
     }


### PR DESCRIPTION
Not ready for merge yet, but PRing to have it here.  
You probably know better how you thought the block/header parsing will work, as my current solution feels kinda hacky.

This syncs a lot further than yesterday though, so it is progress. I won't be around until tomorrow afternoon/evening, so if you want to poke at it (or me), here it is.

367655d should be correct though, that's why it's an extra commit.

Currently it stops syncing at block `bd98a06391115285265c04984e8505229739f6ffa5d498929a91fbe7c281ea7b` with "Aux POW wrong index". I think then none may be wrong there.
