### PR TITLE
Fix arrayMatch.

### DIFF
--- a/src/main/java/org/bitcoinj/core/AuxPoW.java
+++ b/src/main/java/org/bitcoinj/core/AuxPoW.java
@@ -423,12 +423,13 @@ public class AuxPoW extends ChildMessage {
      * @return true if the shorter array is present at the offset, false otherwise.
      */
     static boolean arrayMatch(byte[] script, int offset, byte[] subArray) {
-        for (int matchIdx = 0; matchIdx + offset < script.length && matchIdx < subArray.length; matchIdx++) {
+        int matchIdx;
+        for (matchIdx = 0; matchIdx + offset < script.length && matchIdx < subArray.length; matchIdx++) {
             if (script[offset + matchIdx] != subArray[matchIdx]) {
                 return false;
             }
         }
-        return true;
+        return matchIdx == subArray.length;
     }
 
     /**

--- a/src/test/java/org/bitcoinj/core/AuxPoWTest.java
+++ b/src/test/java/org/bitcoinj/core/AuxPoWTest.java
@@ -12,11 +12,8 @@ import org.libdohj.params.DogecoinMainNetParams;
 
 import static org.bitcoinj.core.Util.getBytes;
 import static org.bitcoinj.core.Utils.reverseBytes;
+import static org.junit.Assert.*;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -391,5 +388,22 @@ public class AuxPoWTest {
         final int expResult = 40;
         final int result = AuxPoW.getExpectedIndex(nonce, chainId, merkleHeight);
         assertEquals(expResult, result);
+    }
+
+    /**
+     * Tests the array matching algorithm for not accepting part of the array when it is in the end of the script.
+     */
+    @Test
+    public void testArrayMatch() {
+        byte[] script = Utils.HEX.decode("089b911f5e471c0e1800f3384281ebec5b372fbb6f358790a92747ade271ccdf");
+        byte[] prefix = Utils.HEX.decode("089b911f");
+        byte[] suffix = Utils.HEX.decode("e271ccdf");
+        byte[] anywhere = Utils.HEX.decode("384281eb");
+        byte[] overTheEnd = Utils.HEX.decode("e271ccdf000000");
+
+        assertTrue(AuxPoW.arrayMatch(script, 0, prefix));
+        assertTrue(AuxPoW.arrayMatch(script, 28, suffix));
+        assertTrue(AuxPoW.arrayMatch(script, 11, anywhere));
+        assertFalse(AuxPoW.arrayMatch(script, 28, overTheEnd));
     }
 }


### PR DESCRIPTION
It would incorrectly return true if just part of the subArray was at the end of the script.
