### PR TITLE
Update to work against BitcoinJ 0.15-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>org.bitcoinj</groupId>
             <artifactId>bitcoinj-core</artifactId>
-            <version>0.14-SNAPSHOT</version>
+            <version>0.15-SNAPSHOT</version>
         </dependency>
     </dependencies>
     <properties>

--- a/src/main/java/com/dogecoin/dogecoinj/protocols/payments/PaymentSession.java
+++ b/src/main/java/com/dogecoin/dogecoinj/protocols/payments/PaymentSession.java
@@ -26,6 +26,7 @@ import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.protobuf.InvalidProtocolBufferException;
 
 import org.bitcoin.protocols.payments.Protos;
+import org.bitcoinj.wallet.SendRequest;
 
 import javax.annotation.Nullable;
 
@@ -291,13 +292,13 @@ public class PaymentSession {
     }
 
     /**
-     * Returns a {@link Wallet.SendRequest} suitable for broadcasting to the network.
+     * Returns a {@link SendRequest} suitable for broadcasting to the network.
      */
-    public Wallet.SendRequest getSendRequest() {
+    public SendRequest getSendRequest() {
         Transaction tx = new Transaction(params);
         for (Protos.Output output : paymentDetails.getOutputsList())
             tx.addOutput(new TransactionOutput(params, tx, Coin.valueOf(output.getAmount()), output.getScript().toByteArray()));
-        return Wallet.SendRequest.forTx(tx).fromPaymentDetails(paymentDetails);
+        return SendRequest.forTx(tx).fromPaymentDetails(paymentDetails);
     }
 
     /**


### PR DESCRIPTION
Changes from BitcoinJ:
- now on 0.15-SNAPSHOT (without tagging 0.14!?)
- bitcoinj/bitcoinj@4e29e4fb made SendRequest a toplevel class

Haven't checked anything but unit tests, as I do not use this as an SPV wallet myself, so there might be more issues that are not covered by basic unit tests.
