### PR TITLE
Fix verification bug in Namecoin.

### DIFF
--- a/namecoin/src/main/java/org/libdohj/names/NameLookupByBlockHashOneFullBlock.java
+++ b/namecoin/src/main/java/org/libdohj/names/NameLookupByBlockHashOneFullBlock.java
@@ -42,6 +42,13 @@ public class NameLookupByBlockHashOneFullBlock implements NameLookupByBlockHash 
         // The full block hasn't been verified in any way!
         // So let's do that now.
         
+        if (! nameFullBlock.getHash().equals(blockHash)) {
+            throw new Exception("Block hash mismatch!");
+        }
+        
+        // Now we know that the received block actually does have a header that matches the hash that we requested.
+        // However, that doesn't mean that the block's contents are valid.
+        
         final EnumSet<Block.VerifyFlag> flags = EnumSet.noneOf(Block.VerifyFlag.class);
         nameFullBlock.verify(-1, flags);
         


### PR DESCRIPTION
P2P full-block by-hash retrieval mode of libdohj-namecoin wasn't verifying that the received block had a header whose hash matched the requested hash.

This probably made it trivially easy to falsify name records, since any internally valid block supplied by a malicious P2P peer (or a MITM attacker) would be accepted, and the name transactions in it trusted as valid, even if the block had (for example) minimum difficulty.

And that is why this code isn't yet deployed to end users.  :)
