### PR TITLE
Remove non-working seed

### DIFF
--- a/core/src/main/java/org/libdohj/params/DogecoinMainNetParams.java
+++ b/core/src/main/java/org/libdohj/params/DogecoinMainNetParams.java
@@ -85,7 +85,6 @@ public class DogecoinMainNetParams extends AbstractDogecoinParams {
         checkpoints.put(400002, Sha256Hash.wrap("a5021d69a83f39aef10f3f24f932068d6ff322c654d20562def3fac5703ce3aa"));
 
         dnsSeeds = new String[] {
-                "seed.dogecoin.com",
                 "seed.multidoge.org",
                 "seed2.multidoge.org",
                 "seed.doger.dogecoin.com"


### PR DESCRIPTION
Having this seed in the peer discovery failing in 100% of the cases makes the overall discovery highly unstable as there also seems to be a bug upstream that lets the whole discovery fail if the first seed fails.