### PR TITLE
update to be compatible with bitcoinj 0.16.1

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -5,7 +5,7 @@ version = '0.15-SNAPSHOT'
 archivesBaseName = 'libdohj-core'
 
 dependencies {
-    api 'org.bitcoinj:bitcoinj-core:0.15.10'
+    api 'org.bitcoinj:bitcoinj-core:0.16.1'
     implementation 'com.madgag.spongycastle:core:1.58.0.0'
     implementation 'com.google.guava:guava:30.0-android'
     implementation 'com.lambdaworks:scrypt:1.4.0'

--- a/core/src/main/java/org/bitcoinj/core/AltcoinBlock.java
+++ b/core/src/main/java/org/bitcoinj/core/AltcoinBlock.java
@@ -27,6 +27,7 @@ import java.io.OutputStream;
 import java.math.BigInteger;
 import java.security.GeneralSecurityException;
 import java.util.BitSet;
+import java.util.Collections;
 import java.util.List;
 
 import static org.bitcoinj.core.Utils.reverseBytes;
@@ -250,8 +251,14 @@ public class AltcoinBlock extends org.bitcoinj.core.Block {
     /** Returns a copy of the block, but without any transactions. */
     @Override
     public Block cloneAsHeader() {
-        AltcoinBlock block = new AltcoinBlock(params, getRawVersion());
-        super.copyBitcoinHeaderTo(block);
+        AltcoinBlock block = new AltcoinBlock(params,
+                getRawVersion(),
+                getPrevBlockHash(),
+                getMerkleRoot(),
+                getTimeSeconds(),
+                getDifficultyTarget(),
+                getNonce(),
+                Collections.emptyList());
         block.auxpow = auxpow;
         return block;
     }

--- a/core/src/main/java/org/bitcoinj/core/MerkleBranch.java
+++ b/core/src/main/java/org/bitcoinj/core/MerkleBranch.java
@@ -96,7 +96,7 @@ public class MerkleBranch extends ChildMessage {
     protected void parse() throws ProtocolException {
         cursor = offset;
 
-        final int hashCount = (int) readVarInt();
+        final int hashCount = (int) readVarInt().longValue();
         optimalEncodingMessageSize += VarInt.sizeOf(hashCount);
         hashes = new ArrayList<Sha256Hash>(hashCount);
         for (int hashIdx = 0; hashIdx < hashCount; hashIdx++) {

--- a/core/src/main/java/org/libdohj/params/AbstractDogecoinParams.java
+++ b/core/src/main/java/org/libdohj/params/AbstractDogecoinParams.java
@@ -90,6 +90,7 @@ public abstract class AbstractDogecoinParams extends NetworkParameters implement
     protected final int newInterval;
     protected final int newTargetTimespan;
     protected final int diffChangeTarget;
+    protected final AltcoinBlock genesisBlock;
 
     protected Logger log = LoggerFactory.getLogger(AbstractDogecoinParams.class);
     public static final int DOGECOIN_PROTOCOL_VERSION_AUXPOW = 70003;

--- a/core/src/main/java/org/libdohj/params/AbstractLitecoinParams.java
+++ b/core/src/main/java/org/libdohj/params/AbstractLitecoinParams.java
@@ -81,6 +81,7 @@ public abstract class AbstractLitecoinParams extends NetworkParameters implement
     private static final Coin BASE_SUBSIDY = COIN.multiply(50);
 
     protected Logger log = LoggerFactory.getLogger(AbstractLitecoinParams.class);
+    protected AltcoinBlock genesisBlock;
 
     public AbstractLitecoinParams() {
         super();

--- a/core/src/main/java/org/libdohj/params/AbstractNamecoinParams.java
+++ b/core/src/main/java/org/libdohj/params/AbstractNamecoinParams.java
@@ -67,6 +67,8 @@ public abstract class AbstractNamecoinParams extends NetworkParameters implement
     public static final String CODE_MNMC = "mNMC";
     /** Currency code for base 1/1,000,000 Namecoin. */
     public static final String CODE_UNMC = "µNMC";
+    
+    protected final AltcoinBlock genesisBlock;
 
     protected int auxpowStartHeight;
     

--- a/core/src/main/java/org/libdohj/params/DogecoinMainNetParams.java
+++ b/core/src/main/java/org/libdohj/params/DogecoinMainNetParams.java
@@ -16,6 +16,7 @@
 
 package org.libdohj.params;
 
+import org.bitcoinj.core.Block;
 import org.bitcoinj.core.Sha256Hash;
 
 import static com.google.common.base.Preconditions.checkState;
@@ -108,6 +109,11 @@ public class DogecoinMainNetParams extends AbstractDogecoinParams {
     public String getPaymentProtocolId() {
         // TODO: CHANGE THIS
         return ID_DOGE_MAINNET;
+    }
+
+    @Override
+    public Block getGenesisBlock() {
+        return genesisBlock;
     }
 
     @Override

--- a/core/src/main/java/org/libdohj/params/DogecoinTestNet3Params.java
+++ b/core/src/main/java/org/libdohj/params/DogecoinTestNet3Params.java
@@ -17,6 +17,7 @@
 
 package org.libdohj.params;
 
+import org.bitcoinj.core.Block;
 import org.bitcoinj.core.Utils;
 import org.spongycastle.util.encoders.Hex;
 
@@ -52,7 +53,6 @@ public class DogecoinTestNet3Params extends AbstractDogecoinParams {
         subsidyDecreaseBlockCount = 100000;
         String genesisHash = genesisBlock.getHashAsString();
         checkState(genesisHash.equals("bb0a78264637406b6360aad926284d544d7049f45189db5664f3c4d07350559e"));
-        alertSigningKey = Hex.decode("042756726da3c7ef515d89212ee1705023d14be389e25fe15611585661b9a20021908b2b80a3c7200a0139dd2b26946606aab0eef9aa7689a6dc2c7eee237fa834");
 
         majorityEnforceBlockUpgrade = TESTNET_MAJORITY_ENFORCE_BLOCK_UPGRADE;
         majorityRejectBlockOutdated = TESTNET_MAJORITY_REJECT_BLOCK_OUTDATED;
@@ -84,6 +84,11 @@ public class DogecoinTestNet3Params extends AbstractDogecoinParams {
     public String getPaymentProtocolId() {
         // TODO: CHANGE ME
         return PAYMENT_PROTOCOL_ID_TESTNET;
+    }
+
+    @Override
+    public Block getGenesisBlock() {
+        return genesisBlock;
     }
 
     @Override

--- a/core/src/main/java/org/libdohj/params/LitecoinMainNetParams.java
+++ b/core/src/main/java/org/libdohj/params/LitecoinMainNetParams.java
@@ -62,7 +62,6 @@ public class LitecoinMainNetParams extends AbstractLitecoinParams {
 
         String genesisHash = genesisBlock.getHashAsString();
         checkState(genesisHash.equals("12a765e31ffd4059bada1e25190f6e98c99d9714d334efa41a195a7e7e04bfe2"));
-        alertSigningKey = Hex.decode("040184710fa689ad5023690c80f3a49c8f13f8d45b8c857fbcbc8bc4a8e4d3eb4b10f4d4604fa08dce601aaf0f470216fe1b51850b4acf21b179c45070ac7b03a9");
 
         majorityEnforceBlockUpgrade = MAINNET_MAJORITY_ENFORCE_BLOCK_UPGRADE;
         majorityRejectBlockOutdated = MAINNET_MAJORITY_REJECT_BLOCK_OUTDATED;
@@ -113,6 +112,11 @@ public class LitecoinMainNetParams extends AbstractLitecoinParams {
     @Override
     public String getPaymentProtocolId() {
         return ID_LITE_MAINNET;
+    }
+
+    @Override
+    public Block getGenesisBlock() {
+        return genesisBlock;
     }
 
     @Override

--- a/core/src/main/java/org/libdohj/params/LitecoinTestNet3Params.java
+++ b/core/src/main/java/org/libdohj/params/LitecoinTestNet3Params.java
@@ -61,7 +61,6 @@ public class LitecoinTestNet3Params extends AbstractLitecoinParams {
 
         String genesisHash = genesisBlock.getHashAsString();
         checkState(genesisHash.equals("f5ae71e26c74beacc88382716aced69cddf3dffff24f384e1808905e0188f68f"));
-        alertSigningKey = Hex.decode("0449623fc74489a947c4b15d579115591add020e53b3490bf47297dfa3762250625f8ecc2fb4fc59f69bdce8f7080f3167808276ed2c79d297054367566038aa82");
 
         majorityEnforceBlockUpgrade = TESTNET_MAJORITY_ENFORCE_BLOCK_UPGRADE;
         majorityRejectBlockOutdated = TESTNET_MAJORITY_REJECT_BLOCK_OUTDATED;
@@ -111,6 +110,11 @@ public class LitecoinTestNet3Params extends AbstractLitecoinParams {
     @Override
     public String getPaymentProtocolId() {
         return ID_LITE_TESTNET;
+    }
+
+    @Override
+    public Block getGenesisBlock() {
+        return genesisBlock;
     }
 
     @Override

--- a/core/src/main/java/org/libdohj/params/NamecoinMainNetParams.java
+++ b/core/src/main/java/org/libdohj/params/NamecoinMainNetParams.java
@@ -16,6 +16,7 @@
 
 package org.libdohj.params;
 
+import org.bitcoinj.core.Block;
 import org.bitcoinj.core.Sha256Hash;
 import org.spongycastle.util.encoders.Hex;
 
@@ -51,8 +52,6 @@ public class NamecoinMainNetParams extends AbstractNamecoinParams {
         String genesisHash = genesisBlock.getHashAsString();
         checkState(genesisHash.equals("000000000062b72c5e2ceb45fbc8587e807c155b0da735e6483dfba2f0a9c770"),
                 genesisHash);
-                // TODO: remove alert key since it's removed from Bitcoin Core / Namecoin Core
-        alertSigningKey = Hex.decode("04ba207043c1575208f08ea6ac27ed2aedd4f84e70b874db129acb08e6109a3bbb7c479ae22565973ebf0ac0391514511a22cb9345bdb772be20cfbd38be578b0c");
 
         majorityEnforceBlockUpgrade = MAINNET_MAJORITY_ENFORCE_BLOCK_UPGRADE;
         majorityRejectBlockOutdated = MAINNET_MAJORITY_REJECT_BLOCK_OUTDATED;
@@ -109,6 +108,11 @@ public class NamecoinMainNetParams extends AbstractNamecoinParams {
     public String getPaymentProtocolId() {
         // TODO: CHANGE THIS (comment from Dogecoin)
         return ID_NMC_MAINNET;
+    }
+
+    @Override
+    public Block getGenesisBlock() {
+        return genesisBlock;
     }
 
     @Override

--- a/namecoin/build.gradle
+++ b/namecoin/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'java-library'
 
 dependencies {
     implementation project(':core')
-    implementation 'org.bitcoinj:bitcoinj-core:0.15.10'
+    implementation 'org.bitcoinj:bitcoinj-core:0.16.1'
     implementation 'com.google.guava:guava:30.0-android'
     implementation 'net.sf.jopt-simple:jopt-simple:4.3'
     implementation 'org.slf4j:slf4j-api:1.7.30'


### PR DESCRIPTION
This is just a quick fix to be able to use some basic functionality.
I noticed there is a 0.16 branch after I finshed mine :( so feel free to close this

genesis block initialization was moved to lazy getter in bitcoinj, it could be done here too, but keeping the change small by just adding the field like it was before

alertSigningKey was removed in bitcoinj, removing here too, even though some forks might use it